### PR TITLE
[Fix] Add exceptions to "pathed_env_vars" config setting

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -380,6 +380,7 @@ config_schema = Schema({
     "release_hooks":                                StrList,
     "context_tracking_context_fields":              StrList,
     "pathed_env_vars":                              StrList,
+    "pathed_env_vars_exceptions":                   StrList,
     "prompt_release_message":                       Bool,
     "critical_styles":                              OptionalStrList,
     "error_styles":                                 OptionalStrList,

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -560,6 +560,10 @@ class ActionInterpreter(object):
 
     @classmethod
     def _is_pathed_key(cls, key):
+        is_exception = any(fnmatch(key, x) for x in config.pathed_env_vars_exceptions)
+        if is_exception:
+            return False
+
         return any(fnmatch(key, x) for x in config.pathed_env_vars)
 
     def normalize_path(self, path):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -578,6 +578,15 @@ pathed_env_vars = [
     "*PATH"
 ]
 
+# This setting works in pair with "path_env_vars" to specify variables
+# that should not be considered as path, and so on, that should not be converted
+# for the current OS.
+# A great example is CMAKE_MODULE_PATH which expects a path with forward slashes.
+# However, if running on Windows, CMAKE_MODULE_PATH will match "*PATH" pattern above
+# and will be converted with non-working backslashes.
+# This setting supports wildcards.
+pathed_env_vars_exceptions = []
+
 # Defines what suites on ``$PATH`` stay visible when a new rez environment is resolved.
 # Possible values are:
 #


### PR DESCRIPTION
# Pull Request: Fix

## TLDR

Add a new config setting to allow the exclusion (exception) of specific variables that could be matched by the setting `pathed_env_vars`.

## Why?

### Context

On Windows, paths use backslashes. Rez handles them pretty well. However, there are some tricky cases where paths should not be converted. The most common one is for the variable `CMAKE_MODULE_PATH` which requires a path with forward slashes (as described [here](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html)).

### Simplified trace (not complete)

- [CMakeBuildSystem._add_build_actions()](https://github.com/AcademySoftwareFoundation/rez/blob/dc2c77757748e87d2abf0967924ee0195aa0f11d/src/rezplugins/build_system/cmake.py#L263)
- [EnvironmentVariable.append()](https://github.com/AcademySoftwareFoundation/rez/blob/dc2c77757748e87d2abf0967924ee0195aa0f11d/src/rez/rex.py#L1152)
- [ActionManager.appendenv()](https://github.com/AcademySoftwareFoundation/rez/blob/dc2c77757748e87d2abf0967924ee0195aa0f11d/src/rez/rex.py#L396)
- [PowerShellBase.appendenv()](https://github.com/AcademySoftwareFoundation/rez/blob/dc2c77757748e87d2abf0967924ee0195aa0f11d/src/rezplugins/shell/_utils/powershell_base.py#L277)
- [ActionInterpreter._is_pathed_key()](https://github.com/AcademySoftwareFoundation/rez/blob/dc2c77757748e87d2abf0967924ee0195aa0f11d/src/rez/rex.py#L561) : `return any(fnmatch(key, x) for x in config.pathed_env_vars)`

Currently, the config setting `pathed_env_vars` allows to define which variable should be considered as path to convert. However, this setting uses wildcards, and not regular expressions. And wildcards do not allow to "exclude" some explicit patterns.

## Potential solutions

The first solution, which should be the best one I guess, would be to use regular expressions instead of wildcards to allow a more precise customisation. However, since wildcards patterns and regex patterns are different, it should not be retro-compatible with everyone's current config.

The second one, which is not API-breaking, is to add a new config setting permitting to mark some paths as exceptions. This is the solution I implemented.

## Result

`rezconfig.py` (default: fully retro-compatible)

```python
pathed_env_vars = [
    "*PATH"
]

pathed_env_vars_exceptions = []
```

`rezconfig_overrides.py` (fixing the CMAKE_MODULE_PATH issue on Windows when using Powershell)

```python
pathed_env_vars_exceptions = [
    "CMAKE_MODULE_PATH"
]
```